### PR TITLE
fix: Replace bare except blocks with specific exception handling in View timeouts

### DIFF
--- a/mkw_stats_bot/mkw_stats/bot.py
+++ b/mkw_stats_bot/mkw_stats/bot.py
@@ -261,8 +261,15 @@ class OCRConfirmationView(discord.ui.View):
 
                 # Schedule deletion
                 asyncio.create_task(self.bot._countdown_and_delete_message(self.message, embed, 30))
-            except:
+            except discord.NotFound:
+                # Message was already deleted
                 pass
+            except discord.Forbidden:
+                logger.warning("Missing permissions to edit OCR confirmation message on timeout")
+            except discord.HTTPException as e:
+                logger.error(f"Failed to edit OCR confirmation message on timeout: {e}")
+            except Exception as e:
+                logger.error(f"Unexpected error editing OCR confirmation message on timeout: {e}", exc_info=True)
 
 
 class ReportIssueView(discord.ui.View):
@@ -293,8 +300,15 @@ class ReportIssueView(discord.ui.View):
         if self.message:
             try:
                 await self.message.delete()
-            except:
+            except discord.NotFound:
+                # Message was already deleted
                 pass
+            except discord.Forbidden:
+                logger.warning("Missing permissions to delete report issue message on timeout")
+            except discord.HTTPException as e:
+                logger.error(f"Failed to delete report issue message on timeout: {e}")
+            except Exception as e:
+                logger.error(f"Unexpected error deleting report issue message on timeout: {e}", exc_info=True)
 
 
 class MarioKartBot(commands.Bot):


### PR DESCRIPTION
## Summary
- Fixed bare `except: pass` blocks in `OCRConfirmationView` and `ReportIssueView` timeout handlers
- Added specific exception handling for Discord API errors with proper logging
- Improved debuggability by logging permission issues and HTTP failures

## Problem
Previously, both View classes used bare `except: pass` blocks in their `on_timeout()` methods, which silently swallowed ALL exceptions including:
- `KeyboardInterrupt`
- `SystemExit`  
- Discord API errors (Forbidden, HTTPException)

This made debugging impossible and could hide serious issues like permission errors or network failures.

## Solution
**Files Changed:**
- `mkw_stats_bot/mkw_stats/bot.py:264-272, 298-311`

**Changes:**
1. Catch specific Discord exceptions:
   - `discord.NotFound`: Silent pass (message already deleted)
   - `discord.Forbidden`: Log warning about missing permissions
   - `discord.HTTPException`: Log error with exception details
   - Generic `Exception`: Log error with full traceback

2. All logging includes context about which message failed to edit/delete

## Impact
- **Severity**: CRITICAL
- **Risk**: Low - only improves error handling, no functionality changes
- **Testing**: Manual - verify timeout handlers log errors appropriately

## Checklist
- [x] Fixed bare except blocks in `OCRConfirmationView.on_timeout()`
- [x] Fixed bare except blocks in `ReportIssueView.on_timeout()`
- [x] Added proper logging for all exception types
- [x] Maintained backward compatibility (NotFound still silent)

Fixes issue #1 from master-debugger report (CRITICAL severity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery for OCR timeouts, with enhanced logging for permission and API issues.

* **Refactor**
  * Refined exception handling for more specific error detection and safer recovery paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->