### PR TITLE
fix: Add interaction defer to prevent Discord timeout on OCR save

### DIFF
--- a/mkw_stats_bot/mkw_stats/bot.py
+++ b/mkw_stats_bot/mkw_stats/bot.py
@@ -725,6 +725,10 @@ class MarioKartBot(commands.Bot):
 
     async def handle_ocr_war_submission_from_view(self, interaction: discord.Interaction, view: OCRConfirmationView):
         """Handle OCR war submission from interactive view."""
+        # Defer the interaction immediately to prevent timeout
+        # This gives us 15 minutes instead of 3 seconds to respond
+        await interaction.response.defer()
+
         try:
             results = view.results
             guild_id = view.guild_id
@@ -826,7 +830,7 @@ class MarioKartBot(commands.Bot):
                 )
 
             # Update message with result (disable view)
-            await interaction.response.edit_message(embed=embed, view=None)
+            await interaction.edit_original_response(embed=embed, view=None)
 
             # Schedule deletion
             asyncio.create_task(self._countdown_and_delete_message(view.message, embed))
@@ -838,7 +842,7 @@ class MarioKartBot(commands.Bot):
                 description=f"An error occurred while saving results: {str(e)}",
                 color=0xff0000
             )
-            await interaction.response.edit_message(embed=embed, view=None)
+            await interaction.edit_original_response(embed=embed, view=None)
             asyncio.create_task(self._countdown_and_delete_message(view.message, embed))
 
     async def handle_ocr_war_submission(self, message: discord.Message, confirmation_data: Dict):


### PR DESCRIPTION
## Problem

When saving OCR war results, users were getting "interaction failed" errors even though the data was saving correctly.

**Error:**
```
404 Not Found (error code: 10062): Unknown interaction
```

**Timeline:**
1. ✅ User clicks "Save War" button
2. ✅ Bot processes 6 players, saves to database (~4 seconds)
3. ❌ Discord kills interaction after 3 seconds
4. ❌ Bot tries to respond but interaction already expired

## Solution

Defer the interaction immediately to tell Discord "I got the click, give me time to process."

**Changes:**
- Added `await interaction.response.defer()` at the start of `handle_ocr_war_submission_from_view()`
- Changed `interaction.response.edit_message()` to `interaction.edit_original_response()`
- Applied to both success and error paths

**Now:**
- Click button → Discord shows loading indicator → wait ~4 seconds → success message appears
- Bot has 15 minutes instead of 3 seconds to complete processing
- No more "interaction failed" errors

## Testing

✅ Data still saves correctly (confirmed in logs)  
✅ User sees loading indicator while processing  
✅ Success message appears when complete  
✅ No more timeout errors

## Impact

- Fixes regression introduced after recent guild_id validation changes
- No change to user experience except fixing the error
- Processing time remains ~4 seconds (15 minutes is just the maximum allowed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal message response handling in the bot's submission processing workflow. The bot now uses an optimized approach for delivering and updating user notifications while maintaining the same functionality and user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->