### PR TITLE
feat: Add last 10 war scores to /stats command and clarify timezone handling

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -842,6 +842,8 @@ class MarioKartCommands(commands.Cog):
                     total_races = stats.get('total_races', 0)
                     if stats.get('last_war_date'):
                         try:
+                            # Parse the date - it's stored as just a date (no time)
+                            # Display in EST timezone
                             date_obj = datetime.strptime(stats['last_war_date'], '%Y-%m-%d')
                             last_war = date_obj.strftime('%b %d, %Y')
                         except (ValueError, TypeError) as e:
@@ -852,6 +854,13 @@ class MarioKartCommands(commands.Cog):
 
                     activity_text = f"```\nWars:       {war_count:.1f}\nRaces:      {total_races}\nLast War:   {last_war}\n```"
                     embed.add_field(name="📅 Activity", value=activity_text, inline=True)
+
+                    # Last 10 War Scores
+                    last_scores = self.bot.db.get_player_last_war_scores(resolved_player, limit=10, guild_id=guild_id)
+                    if last_scores:
+                        scores_list = [str(score['score']) for score in last_scores]
+                        scores_text = f"```\n{', '.join(scores_list)}\n```"
+                        embed.add_field(name="📜 Last 10 Wars", value=scores_text, inline=False)
 
                     # Footer
                     embed.set_footer(text=f"Guild-Specific {scope_text}")


### PR DESCRIPTION
## Summary

Enhances the `/stats` command with two improvements:
1. **Last 10 War Scores Display** - Shows a player's most recent 10 war scores
2. **Timezone Clarification** - Documents that war dates are already stored in Eastern Time

## Changes

### New Database Method
- **File**: `mkw_stats_bot/mkw_stats/database.py`
- **Method**: `get_player_last_war_scores(player_name, limit=10, guild_id=0)`
- Queries `player_war_performances` table for optimized performance
- Returns list of recent war scores ordered newest to oldest
- Fully supports multi-guild architecture with guild_id filtering

### Enhanced Stats Command
- **File**: `mkw_stats_bot/mkw_stats/commands.py`
- Added "📜 Last 10 Wars" section to stats embed
- Displays scores in simple comma-separated format
- Only shows when player has war history
- Added clarifying comment about timezone handling

## Example Output

```
📜 Last 10 Wars
105, 98, 112, 89, 95, 103, 91, 107, 88, 99
```

## Design Decisions

- **Minimalistic Design**: Simple comma-separated scores in code block
- **Positioning**: Full-width field below existing Activity stats
- **Conditional Display**: Only appears for players with war scores
- **Performance**: Uses optimized player_war_performances table
- **Guild-Aware**: Proper guild_id filtering for multi-guild support

## Testing Checklist

- [ ] Test `/stats player:PlayerName` with player who has 10+ wars
- [ ] Test with player who has fewer than 10 wars
- [ ] Test with new player who has no wars
- [ ] Verify scores display in newest-to-oldest order
- [ ] Test multi-guild isolation (different guilds show different scores)
- [ ] Verify Last War date displays correctly in Eastern Time

## Timezone Investigation

The investigation revealed that war dates are **already stored in Eastern Time** (America/New_York timezone) in the database. The `wars` table uses:
```python
eastern_tz = zoneinfo.ZoneInfo('America/New_York')
eastern_now = datetime.now(eastern_tz)
```

This timezone automatically handles EST/EDT transitions, so no conversion was needed. Added a clarifying comment for future developers.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Number of Wars" as a new sorting option for leaderboards and stats commands
  * Stats now display the last 10 war scores in a dedicated field when available

* **Improvements**
  * Updated sorting label from "Average Differential" to "Team Differential" for clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->