### PR TITLE
hotfix: creating (N) next to the last wars so it specifically tells the user its not a 12 player race

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -858,7 +858,16 @@ class MarioKartCommands(commands.Cog):
                     # Last 10 War Scores
                     last_scores = self.bot.db.get_player_last_war_scores(resolved_player, limit=10, guild_id=guild_id)
                     if last_scores:
-                        scores_list = [str(score['score']) for score in last_scores]
+                        # Format scores with race count notation for non-standard wars
+                        scores_list = []
+                        for score in last_scores:
+                            score_value = score['score']
+                            race_count = score.get('race_count', 12)
+                            # Only show race count if it's not the standard 12 races
+                            if race_count != 12:
+                                scores_list.append(f"{score_value} ({race_count})")
+                            else:
+                                scores_list.append(str(score_value))
                         scores_text = f"```\n{', '.join(scores_list)}\n```"
                         embed.add_field(name="📜 Last 10 Wars", value=scores_text, inline=False)
 

--- a/mkw_stats_bot/mkw_stats/database.py
+++ b/mkw_stats_bot/mkw_stats/database.py
@@ -1380,7 +1380,7 @@ class DatabaseManager:
             guild_id: Guild ID
 
         Returns:
-            List of dicts with war_date and score, ordered newest to oldest
+            List of dicts with war_date, score, and race_count, ordered newest to oldest
         """
         try:
             with self.get_connection() as conn:
@@ -1399,9 +1399,9 @@ class DatabaseManager:
 
                 player_id = result[0]
 
-                # Get last N war scores
+                # Get last N war scores with race count
                 cursor.execute("""
-                    SELECT w.war_date, pwp.score
+                    SELECT w.war_date, pwp.score, w.race_count
                     FROM player_war_performances pwp
                     JOIN wars w ON pwp.war_id = w.id
                     WHERE pwp.player_id = %s AND w.guild_id = %s
@@ -1413,7 +1413,8 @@ class DatabaseManager:
                 return [
                     {
                         'war_date': row[0].isoformat() if row[0] else None,
-                        'score': row[1]
+                        'score': row[1],
+                        'race_count': row[2]
                     }
                     for row in results
                 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Number of Wars" as a leaderboard sort option
  * New "Last 10 Wars" section in player stats displaying formatted scores with race counts

* **Improvements**
  * Renamed "Average Differential" leaderboard label to "Team Differential"
  * Enhanced date parsing with improved error handling for last war date display

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->