### PR TITLE
fix: Add code block formatting to Last 10 Wars display

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -869,7 +869,7 @@ class MarioKartCommands(commands.Cog):
                                 scores_list.append(f"*{score_value} ({race_count})*")
                             else:
                                 scores_list.append(str(score_value))
-                        scores_text = ', '.join(scores_list)
+                        scores_text = f"```\n{', '.join(scores_list)}\n```"
                         embed.add_field(name="📜 Last 10 Wars", value=scores_text, inline=False)
 
                     # Footer


### PR DESCRIPTION
## Summary

Fixes the "Last 10 Wars" section to display in a black code block like the other stats sections (Performance, Activity, etc.).

## Issue

The scores were displaying as plain text instead of in the formatted code block style:

**Before:**
```
📜 Last 10 Wars
89, 106, 123, 113, 128, 22, 86, 88, 107, 59
```

**After (with code block):**
```
📜 Last 10 Wars
```
89, 106, 123, 113, 128, 22, 86, 88, 107, 59
```
```

## Changes

- **File**: `mkw_stats_bot/mkw_stats/commands.py`
- Wrapped the scores in triple backticks for consistent code block formatting
- Matches the styling of Performance, Differential, and Activity sections

## Testing

- [ ] Verify Last 10 Wars appears in black code block
- [ ] Confirm formatting matches other stats sections
- [ ] Test with players who have various war counts

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Last 10 Wars scores are now displayed in a code block format, providing enhanced visual distinction and improved readability in the chat interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->