### PR TITLE
hotfix: Fix NameError - cv_percent uses undefined total_wars

### DIFF
--- a/mkw_stats_bot/mkw_stats/database.py
+++ b/mkw_stats_bot/mkw_stats/database.py
@@ -1179,11 +1179,6 @@ class DatabaseManager:
                 stddev_result = cursor.fetchone()
                 score_stddev = float(stddev_result[0]) if stddev_result and stddev_result[0] is not None else 0.0
 
-                # Calculate CV% (Coefficient of Variation)
-                average_score = float(result[4]) if result[4] else 0.0
-                # Only calculate CV% for players with at least 2 wars (need variance)
-                cv_percent = (score_stddev / average_score * 100) if average_score > 0 and total_wars >= 2 else None
-
                 # Calculate win/loss/tie record from team differentials
                 cursor.execute("""
                     SELECT COUNT(CASE WHEN w.team_differential > 0 THEN 1 END),
@@ -1200,6 +1195,11 @@ class DatabaseManager:
                 ties = record_stats[2] if record_stats else 0
                 total_wars = wins + losses + ties
                 win_percentage = (wins / total_wars * 100) if total_wars > 0 else 0.0
+
+                # Calculate CV% (Coefficient of Variation) - must come after total_wars is defined
+                average_score = float(result[4]) if result[4] else 0.0
+                # Only calculate CV% for players with at least 2 wars (need variance)
+                cv_percent = (score_stddev / average_score * 100) if average_score > 0 and total_wars >= 2 else None
 
                 return {
                     'player_name': player_name,


### PR DESCRIPTION
## Critical Bug Fix

Fixes a **NameError** that broke the `/stats` leaderboard, causing all players to show "No wars yet" even when they have war data.

## Problem

In PR #31 (CV% feature), the `cv_percent` calculation referenced `total_wars` before it was defined:

```python
# Line 1185 - BUG: total_wars not defined yet
cv_percent = (score_stddev / average_score * 100) if average_score > 0 and total_wars >= 2 else None

# Line 1201 - total_wars defined HERE
total_wars = wins + losses + ties
```

### Impact
- `NameError: name 'total_wars' is not defined` thrown
- Exception silently caught by handler (line 1228-1230)
- `get_player_stats()` returned `None` for all players
- **All players showed "No wars yet" in `/stats` leaderboard**

## Solution

Moved CV% calculation block to execute **after** `total_wars` is defined:

```python
# Now in correct order:
# Lines 1182-1197: Calculate wins/losses/ties and total_wars
total_wars = wins + losses + ties

# Lines 1199-1202: Calculate CV% using total_wars
cv_percent = (score_stddev / average_score * 100) if average_score > 0 and total_wars >= 2 else None
```

## Changes
- **File**: `mkw_stats_bot/mkw_stats/database.py`
- **Lines**: 1179-1202
- **Type**: Variable reordering (no logic changes)

## Testing
- ✅ Code compiles successfully
- ✅ Variable scope validated
- ✅ `/stats` leaderboard now displays player data correctly

## Related Issues
- Introduced in: PR #31 (feat: Add CV% metric and refactor /stats leaderboard display)
- Regression: `/stats` showing "No wars yet" for all players

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calculation order issue in player statistics to ensure dependent values are computed correctly and consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->