### PR TITLE
feat: Bold sorted column in /stats leaderboard

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -116,25 +116,34 @@ class LeaderboardView(discord.ui.View):
                 avg_score = player.get('average_score', 0.0)
                 war_count = float(player.get('war_count', 0))
 
-                # Base format: #. [flag] [name] | [avg] avg | [wars] wars
-                player_str = f"{rank}. {flag} **{player['player_name']}** | {avg_score:.1f} avg | {war_count:.1f} wars"
+                # Bold the column being sorted by
+                # Default (None) or "average" sorts by avg, "warcount" sorts by wars
+                if self.sortby in [None, 'average']:
+                    # Bold average score
+                    player_str = f"{rank}. {flag} **{player['player_name']}** | **{avg_score:.1f}** avg | {war_count:.1f} wars"
+                elif self.sortby == 'warcount':
+                    # Bold war count
+                    player_str = f"{rank}. {flag} **{player['player_name']}** | {avg_score:.1f} avg | **{war_count:.1f}** wars"
+                else:
+                    # For other sorts (winrate, avgdiff, cv), don't bold base columns
+                    player_str = f"{rank}. {flag} **{player['player_name']}** | {avg_score:.1f} avg | {war_count:.1f} wars"
 
-                # Add third column based on sort type
+                # Add third column based on sort type (and bold it)
                 if show_third_column:
                     if self.sortby == 'winrate':
                         win_pct = player.get('win_percentage', 0.0)
-                        player_str += f" | {win_pct:.1f}%"
+                        player_str += f" | **{win_pct:.1f}%**"
                     elif self.sortby == 'avgdiff':
                         total_diff = player.get('total_team_differential', 0)
                         avg_diff = total_diff / war_count if war_count > 0 else 0
                         diff_symbol = "+" if avg_diff >= 0 else ""
-                        player_str += f" | {diff_symbol}{avg_diff:.1f} diff"
+                        player_str += f" | **{diff_symbol}{avg_diff:.1f}** diff"
                     elif self.sortby == 'cv':
                         cv_pct = player.get('cv_percent')
                         if cv_pct is not None:
-                            player_str += f" | {cv_pct:.1f}%"
+                            player_str += f" | **{cv_pct:.1f}%**"
                         else:
-                            player_str += " | N/A"
+                            player_str += " | **N/A**"
 
                 leaderboard_text.append(player_str)
             else:


### PR DESCRIPTION
## Summary
Adds **bold formatting** to the column being sorted by in the `/stats` leaderboard, making it immediately clear which metric determines player ranking.

## Problem
When users view the leaderboard with different sort options, it's not visually obvious which column is being used for ranking. Users have to read the title carefully or guess based on the order.

## Solution
Automatically bold the value that corresponds to the active sort method:

### Examples

**Default / Sort by Average:**
```
📊 Player Statistics Leaderboard
Top Players
1. 🇺🇸 Unkwn | **104.3** avg | 41.8 wars
2. 🇺🇸 Etane | **100.2** avg | 11.4 wars
```

**Sort by War Count:**
```
📊 Player Statistics • Sorted by Number of Wars
Top Players
1. 🇺🇸 Zay | 83.8 avg | **82.6** wars
2. 🇺🇸 Ghost | 81.5 avg | **45.0** wars
```

**Sort by Consistency (CV%):**
```
📊 Player Statistics • Sorted by Consistency
Top Players
1. 🇺🇸 Zay | 83.8 avg | 82.6 wars | **7.2%**
2. 🇺🇸 Ghost | 81.5 avg | 45.0 wars | **8.9%**
```

**Sort by Win Rate:**
```
📊 Player Statistics • Sorted by Win Rate
Top Players
1. 🇺🇸 Cam | 91.5 avg | 29.0 wars | **65.5%**
2. 🇺🇸 Unkwn | 104.3 avg | 41.8 wars | **61.2%**
```

**Sort by Team Differential:**
```
📊 Player Statistics • Sorted by Team Differential
Top Players
1. 🇺🇸 Unkwn | 104.3 avg | 41.8 wars | **+29.1** diff
2. 🇺🇸 Cam | 91.5 avg | 29.0 wars | **+29.4** diff
```

## Implementation

Updated `LeaderboardView.create_embed()` in `commands.py` to conditionally bold values:
- Checks `self.sortby` to determine which column is active
- Wraps the appropriate value in `**value**` for Discord bold formatting
- Maintains same data display, just adds visual emphasis

## Benefits
- ✅ **Improved Visual Hierarchy**: Sorted column stands out immediately
- ✅ **Better UX**: No guessing which metric determines ranking
- ✅ **Consistent Design**: Works across all 5 sort options
- ✅ **No Breaking Changes**: Pure visual enhancement

## Testing Checklist
- [x] Default sort (by average) bolds average score
- [x] Sort by war count bolds war count
- [x] Sort by win rate bolds win rate percentage
- [x] Sort by team differential bolds differential value
- [x] Sort by consistency bolds CV% value
- [x] "N/A" values are also bolded when sorted by CV%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Leaderboard now bolds the column used for primary sorting
  * Additional stat columns in leaderboard entries are displayed in bold for visual emphasis

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->