### PR TITLE
fix: Convert Decimal to float in get_player_stats_last_x_wars to fix avg10 calculation

### DIFF
--- a/mkw_stats_bot/mkw_stats/database.py
+++ b/mkw_stats_bot/mkw_stats/database.py
@@ -1297,12 +1297,13 @@ class DatabaseManager:
                     war_date, race_count, team_diff, score, races_played, war_participation = perf
                     total_score += score
                     total_races += races_played
-                    total_war_participation += float(war_participation)
+                    war_participation_float = float(war_participation)
+                    total_war_participation += war_participation_float
                     # Normalize score by participation for stddev calculation
-                    normalized_score = score / war_participation if war_participation > 0 else score
+                    normalized_score = score / war_participation_float if war_participation_float > 0 else score
                     scores_list.append(normalized_score)  # Collect normalized scores for stddev calculation
                     # Scale team_differential by war_participation for fractional wars
-                    scaled_differential = int((team_diff or 0) * war_participation)
+                    scaled_differential = int((team_diff or 0) * war_participation_float)
                     total_team_differential += scaled_differential
 
                     # Calculate win/loss/tie


### PR DESCRIPTION
## Summary

Fixes the Railway error preventing avg10 from being calculated and displayed in `/stats` output.

**Error**: `TypeError: unsupported operand type(s) for /: 'decimal.Decimal' and 'float'`

## Root Cause

The `war_participation` column is defined as `DECIMAL(4,3)` in PostgreSQL, which returns `Decimal` objects when queried. When performing arithmetic operations (division, multiplication) between `Decimal` and `int`/`float` types, Python raises a `TypeError` to prevent implicit precision loss.

**Problematic lines**:
- Line 1302: `normalized_score = score / war_participation` 
- Line 1305: `scaled_differential = int((team_diff or 0) * war_participation)`

While line 1300 correctly converted to float for `total_war_participation`, the subsequent arithmetic operations were still using the raw `Decimal` value.

## Solution

Convert `war_participation` to `float` once at the start of the loop iteration, then use `war_participation_float` consistently for all arithmetic operations.

**Changes** (mkw_stats_bot/mkw_stats/database.py:1300-1307):
```python
# Before
total_war_participation += float(war_participation)
normalized_score = score / war_participation if war_participation > 0 else score
scaled_differential = int((team_diff or 0) * war_participation)

# After
war_participation_float = float(war_participation)
total_war_participation += war_participation_float
normalized_score = score / war_participation_float if war_participation_float > 0 else score
scaled_differential = int((team_diff or 0) * war_participation_float)
```

## Impact

### Before Fix
- Railway logs show: `ERROR | ❌ Error getting player stats for last 10 wars: unsupported operand type(s) for /: 'decimal.Decimal' and 'float'`
- avg10 metric missing from `/stats` display
- Users only see: Highest, Average, Lowest (no avg10)

### After Fix
- ✅ No more type errors in Railway logs
- ✅ avg10 calculates successfully
- ✅ avg10 displays in `/stats` output for players with ≥10 wars

**Expected `/stats` output after fix**:
```
⚔️ Performance
Highest:    118
Average:    85.4
avg10:      82.1  ← Now visible
Lowest:     63
```

## Testing

- [x] Tested locally with PostgreSQL database
- [x] Verified Decimal → float conversion works correctly
- [ ] Deploy to Railway and verify avg10 appears in `/stats`
- [ ] Check Railway logs for absence of type errors

## Related Issues

- Companion to PR #34 (Add avg10 metric feature)
- Fixes production bug discovered in Railway deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in player war participation statistics calculations.
  * Enhanced handling of edge cases in war participation data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->