### PR TITLE
feat: Add HtSk (Hotstreak) metric to player stats

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -880,6 +880,8 @@ class MarioKartCommands(commands.Cog):
         # Optimize: reuse stats if lastxwars already equals 10
         avg10_score = None
         htsk_score = None
+        overall_avg = avg_score  # Default to current avg (which is overall avg in normal case)
+
         if lastxwars == 10:
             # Reuse existing calculation to avoid duplicate query
             avg10_score = avg_score
@@ -887,8 +889,9 @@ class MarioKartCommands(commands.Cog):
             # When viewing last 10 wars, we need to fetch overall avg for comparison
             overall_stats = self.bot.db.get_player_stats(player_name, guild_id)
             if overall_stats:
-                overall_avg = overall_stats.get('average_score', 0.0)
-                htsk_score = avg10_score - overall_avg
+                fetched_avg = overall_stats.get('average_score')
+                if fetched_avg is not None and fetched_avg > 0:
+                    overall_avg = fetched_avg
         else:
             # Fetch avg10, but only show if player has at least 10 wars
             avg10_stats = self.bot.db.get_player_stats_last_x_wars(player_name, 10, guild_id)
@@ -896,16 +899,18 @@ class MarioKartCommands(commands.Cog):
                 # Only display avg10 if player has participated in at least 10 wars
                 war_count = avg10_stats.get('war_count', 0)
                 if war_count >= 10:
-                    avg10_score = avg10_stats.get('average_score', 0.0)
-                    # HtSk = avg10 - avg (current avg_score is the overall average)
-                    htsk_score = avg10_score - avg_score
+                    avg10_score = avg10_stats.get('average_score')
+
+        # Calculate HtSk if we have valid avg10 data
+        if avg10_score is not None and avg10_score > 0 and overall_avg > 0:
+            htsk_score = avg10_score - overall_avg
 
         # Build performance text with avg10 and HtSk
         if avg10_score is not None and htsk_score is not None:
             htsk_sign = "+" if htsk_score >= 0 else ""
             performance_text = f"```\nHighest:    {highest_score}\nAverage:    {avg_score:.1f}\navg10:      {avg10_score:.1f}\nHtSk:       {htsk_sign}{htsk_score:.2f}\nLowest:     {lowest_score}\n```"
         elif avg10_score is not None:
-            # Show avg10 but not HtSk (shouldn't happen, but fallback)
+            # Show avg10 without HtSk (edge case: missing data for HtSk calculation)
             performance_text = f"```\nHighest:    {highest_score}\nAverage:    {avg_score:.1f}\navg10:      {avg10_score:.1f}\nLowest:     {lowest_score}\n```"
         else:
             performance_text = f"```\nHighest:    {highest_score}\nAverage:    {avg_score:.1f}\nLowest:     {lowest_score}\n```"


### PR DESCRIPTION
## Summary
Adds the **HtSk (Hotstreak)** metric to the `/stats` command, showing player performance trajectory by comparing recent form to lifetime average.

## What is HtSk?
**HtSk = avg10 - avg**

- **Positive value**: Player is improving (recent performance better than lifetime average)
  - Example: avg = 85.0, avg10 = 91.3 → HtSk = +6.30 🔥
- **Negative value**: Player is declining (recent performance worse than lifetime average)
  - Example: avg = 85.0, avg10 = 78.7 → HtSk = -6.30 📉
- **Zero/near-zero**: Consistent performance

## Changes
- Added HtSk calculation in `_display_player_stats()` method
- Displays with +/- sign and 2 decimal precision
- Only shown for players with 10+ wars (requires avg10)
- Handles edge case when viewing `lastxwars=10` (fetches overall avg separately for comparison)

## Display Example
```
⚔️ Performance
Highest:    150
Average:    85.5
avg10:      92.3
HtSk:       +6.80  ← New!
Lowest:     65
```

## Technical Details
- **No database schema changes** - calculated on-demand from existing avg and avg10
- **No performance impact** - reuses existing queries where possible
- **Multi-guild safe** - maintains guild_id isolation
- Gracefully degrades (hidden) for players with <10 wars

## Test Plan
- [x] Verify HtSk calculation: avg10 - avg
- [x] Verify +/- sign formatting
- [x] Test with players who have <10 wars (HtSk should not display)
- [x] Test with players who have exactly 10 wars
- [x] Test with players who have >10 wars
- [x] Test viewing with lastxwars=10 parameter
- [x] Test multi-guild isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Hotstreak" metric to player performance stats — shows recent 10-war variance from career average.
  * Hotstreak displays alongside Highest, Average, Avg10 and Lowest when recent and career data are available; falls back to existing summary formatting when not.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->