### PR TITLE
feat: change /assignplayers to use comma-separated player names

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -2755,18 +2755,19 @@ class MarioKartCommands(commands.Cog):
             return []
 
     @app_commands.command(name="assignplayers", description="Assign multiple players to a team")
-    @app_commands.describe(players="Space-separated list of player names (minimum 1 player)", team_name="Team to assign players to")
-    @app_commands.autocomplete(players=player_autocomplete, team_name=team_autocomplete)
+    @app_commands.describe(players="Comma-separated player names (e.g. 'Player1, Player2, CAP ahaha')", team_name="Team to assign players to")
+    @app_commands.autocomplete(team_name=team_autocomplete)
     @require_guild_setup
     async def assign_players_to_team(self, interaction: discord.Interaction, players: str, team_name: str):
         """Assign multiple players to a team."""
         try:
             guild_id = self.get_guild_id(interaction)
-            
-            # Parse player names from space-separated string
-            player_names = players.strip().split()
+
+            # Parse player names from comma-separated string
+            # Strip whitespace from each name to handle "Player1, Player2" and "Player1,Player2"
+            player_names = [name.strip() for name in players.split(',') if name.strip()]
             if len(player_names) == 0:
-                await interaction.response.send_message("❌ Please provide at least one player name.")
+                await interaction.response.send_message("❌ Please provide at least one player name. Use commas to separate multiple players.")
                 return
             
             # Validate team name


### PR DESCRIPTION
## Summary
- Changed `/assignplayers` from space-separated to comma-separated player names
- Fixes issue with players who have spaces in their names (e.g. "CAP ahaha")
- Removed autocomplete from players parameter (doesn't work with multiple values)
- Kept autocomplete on team_name parameter

## Problem
The previous implementation used space-separated player names, which broke for players with spaces in their names:
```
/assignplayers players:Player1 CAP ahaha team_name:Solar Storm
❌ Would try to assign: "Player1", "CAP", "ahaha" (3 players instead of 2)
```

## Solution
Changed to comma-separated format:
```
/assignplayers players:Player1, CAP ahaha team_name:Solar Storm
✅ Will assign: "Player1", "CAP ahaha" (correctly handles spaces)
```

## Changes
- Parse player names by splitting on commas instead of spaces
- Strip whitespace from each name to handle "Player1, Player2" and "Player1,Player2"
- Updated description to show comma-separated format with examples
- Removed autocomplete from players parameter (autocomplete only works for single values)

## Test plan
- [ ] Test with players containing spaces: `/assignplayers players:"CAP ahaha, Player Name" team_name:Team1`
- [ ] Test with multiple players: `/assignplayers players:"Player1, Player2, Player3" team_name:Team1`
- [ ] Test with single player: `/assignplayers players:"Player1" team_name:Team1`
- [ ] Verify team autocomplete still works on team_name parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)