### PR TITLE
feat: add ally indicator to global leaderboard

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -392,13 +392,16 @@ class GlobalLeaderboardView(discord.ui.View):
             guild_id = player.get('guild_id', 0)
             team_name = player.get('team', 'Unassigned')
             team_tag = ""
+            is_ally = (team_name == 'Unassigned')
+
             if guild_id in self.all_team_tags and team_name in self.all_team_tags[guild_id]:
                 tag = self.all_team_tags[guild_id][team_name]
                 team_tag = f"*{tag}* "  # Italicized tag with space
 
-            # Get player display name
+            # Get player display name with asterisk for allies
             player_name = player['player_name'][:25]
-            display_name = f"{team_tag}{player_name}"
+            ally_indicator = "*" if is_ally else ""
+            display_name = f"{team_tag}{player_name}{ally_indicator}"
 
             if player.get('war_count', 0) > 0:
                 avg_score = player.get('average_score', 0.0)
@@ -492,8 +495,8 @@ class GlobalLeaderboardView(discord.ui.View):
             inline=False
         )
 
-        # Footer with page info
-        embed.set_footer(text=f"Page {self.current_page}/{self.total_pages} • {self.total_players_count} Total Players")
+        # Footer with page info and legend
+        embed.set_footer(text=f"Page {self.current_page}/{self.total_pages} • {self.total_players_count} Total Players • * = Ally (not assigned to team)")
 
         return embed
 


### PR DESCRIPTION
## Summary
Add asterisk (*) marker for players not assigned to a team (allies) in the global leaderboard with legend in footer explaining the indicator.

## Motivation
- Players need visual indication of who is unassigned to a team
- Makes leaderboard more informative at a glance
- Legend in footer explains the meaning of the asterisk

## Changes Made
- Added `is_ally` flag to detect unassigned players (team == 'Unassigned')
- Added asterisk (*) suffix to player names for allies on display
- Updated footer to include legend: "* = Ally (not assigned to team)"

## Impact
- Improves leaderboard readability
- Players can quickly identify which competitors are not assigned to teams
- Better visual distinction in global leaderboard view

## Testing
- [ ] Verify asterisk appears for unassigned players in leaderboard
- [ ] Confirm legend displays in footer
- [ ] Test pagination to ensure footer appears on all pages
- [ ] Verify assigned players do not show asterisk