### PR TITLE
fix: Railway restart policy to ALWAYS

### DIFF
--- a/mkw_stats_bot/railway.toml
+++ b/mkw_stats_bot/railway.toml
@@ -5,5 +5,4 @@ builder = "DOCKERFILE"
 
 [deploy]
 startCommand = "python main.py"
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 10
+restartPolicyType = "ALWAYS"


### PR DESCRIPTION
## Summary
- Changed Railway restart policy from `ON_FAILURE` (max 10 retries) to `ALWAYS`
- Bot was crashing on Discord API connection timeouts and not restarting because the process may have exited cleanly (code 0), which `ON_FAILURE` doesn't catch
- `ALWAYS` ensures the bot auto-restarts regardless of exit reason, with Railway's built-in exponential backoff

## Context
Bot went down due to `Connection timeout to host https://discord.com/api/v10/users/@me` and stayed down because Railway didn't restart the container.

## Test plan
- [ ] Merge and verify Railway dashboard shows restart policy as "Always"
- [ ] Confirm bot restarts automatically after next crash/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)