### PR TITLE
chore: add next-env.d.ts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ out/
 *.png 
 
 node_modules/
+.next/
+next-env.d.ts
 
 # Claude Code config
 .claude/


### PR DESCRIPTION
## Summary
- Add `next-env.d.ts` and `.next/` to gitignore (Next.js auto-generated files that shouldn't be tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)