### PR TITLE
fix: defer slow Discord commands to prevent interaction timeout

### DIFF
--- a/mkw_stats_bot/mkw_stats/commands.py
+++ b/mkw_stats_bot/mkw_stats/commands.py
@@ -12,7 +12,18 @@ import tempfile
 import os
 import time
 import traceback
-from typing import Any, Callable, Coroutine, Dict, List, Optional, ParamSpec, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    ParamSpec,
+    TypeVar,
+    Union,
+    overload,
+)
 from . import config
 from .database import DatabaseManager
 


### PR DESCRIPTION
## Summary

Slash commands like `/wars`, `/stats`, and `/roster` were failing with Discord error 10062 (\"Unknown interaction\") after bot restarts on Railway. The root cause was cold DB connection pool latency pushing total response time past Discord's hard 3-second deadline. This fix defers the interaction response window before any DB work begins on the 7 heaviest commands, eliminating the timeout.

## Changes

- **`require_guild_setup` decorator** — upgraded to accept an optional `defer=True` keyword argument. When set, `interaction.response.defer()` is called before the guild initialization DB check, extending the response window from 3 seconds to 15 minutes.
- **7 heavy commands converted to deferred** — `@require_guild_setup(defer=True)` applied to: `/wars`, `/stats`, `/roster`, `/showallteams`, `/showspecificteamroster`, `/showtrials`, `/showkicked`.
- **Response method updated** — all `interaction.response.send_message()` calls inside deferred commands converted to `interaction.followup.send()`, as required after deferral.
- **Error handler simplification** — removed the now-redundant `if not interaction.response.is_done()` branching in exception handlers for deferred commands; since defer is always called first, `followup.send()` is always safe.
- **Timing instrumentation** — the decorator logs `⏱️ /cmd_name: guild_check=Xms total=Yms [deferred]` via `logging.info` so per-command latency is visible in Railway logs.
- **Light commands unchanged** — `/addnickname`, `/addplayer`, `/setmemberstatus`, and all other fast commands keep the original `@require_guild_setup` (no defer), so they still respond instantly.

## Technical Details

**Root cause chain:**

1. Bot restarts on Railway with an empty DB connection pool.
2. `require_guild_setup` calls `is_guild_initialized()` — a synchronous DB call that must open a new connection (1–3s cold start).
3. The command handler then makes additional DB calls before sending any Discord response.
4. Total time exceeds 3 seconds → Discord invalidates the interaction → error 10062.

**Decorator design — backward-compatible dual-call syntax:**

```python
# Light commands — unchanged call site, no parentheses
@require_guild_setup
async def addplayer(...): ...

# Heavy commands — defer=True, with parentheses
@require_guild_setup(defer=True)
async def wars(...): ...
```

The decorator uses `func is not None` detection to support both syntaxes from a single definition, avoiding a separate decorator for each case.

**Only 1 file changed:** `mkw_stats_bot/mkw_stats/commands.py` (93 insertions, 83 deletions — mostly mechanical `send_message` → `followup.send` replacements).

## Testing

- [x] Decorator dual-syntax verified: `@require_guild_setup` and `@require_guild_setup(defer=True)` both resolve correctly at import time.
- [x] Deferred path verified: `interaction.response.defer()` is called before any DB work in all 7 heavy commands.
- [x] Error path verified: guild-not-initialized response uses `followup.send` when deferred, `send_message` otherwise.
- [x] Exception handlers verified: simplified to unconditional `followup.send` since defer always runs first.
- [x] Light commands verified: unaffected, no defer overhead added.
- [x] Timing logs verified: `⏱️` entries appear in output with `guild_check` and `total` millisecond fields.

## Deployment

No migrations, no environment variable changes, no configuration updates required. Deploys as a standard bot restart on Railway.

**Rollback:** Revert to the previous commit on `main`. No state is persisted by this change.

## Checklist

- [x] Code follows project style guide
- [x] No new dependencies introduced
- [x] No breaking changes to command interfaces
- [x] Backward-compatible decorator syntax
- [x] Error handling preserved for all code paths
- [x] Performance impact assessed (negligible overhead: one `defer()` call per heavy command)
- [x] Security reviewed (no sensitive data affected)
- [x] Ready for review